### PR TITLE
COMPASS-426 use new _.omitBy and _.pickBy lodash fns

### DIFF
--- a/lib/backends/splice.js
+++ b/lib/backends/splice.js
@@ -28,13 +28,13 @@ function SpliceBackend(options) {
   // patch the serialize methods in both backends
   var condition = options.secureCondition;
   LocalBackend.prototype.serialize = function(model) {
-    var res = _.omit(model.serialize(), condition);
+    var res = _.omitBy(model.serialize(), condition);
     return res;
   };
   this.localBackend = new LocalBackend(options);
 
   SecureBackend.prototype.serialize = function(model) {
-    var res = _.pick(model.serialize(), condition);
+    var res = _.pickBy(model.serialize(), condition);
     return res;
   };
   this.secureBackend = new SecureBackend(options);

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "electron-mocha": "^2.3.1",
     "electron-prebuilt": "^1.2.8",
-    "eslint-config-mongodb-js": "^1.0.5",
+    "eslint-config-mongodb-js": "^2.2.0",
     "mocha": "^2.3.3",
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.2.5",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ampersand-rest-collection": "^5.0.0",
     "ampersand-sync": "^4.0.3",
     "async": "^1.5.0",
-    "debug": "^2.2.0",
+    "debug": "mongodb-js/debug#v2.2.3",
     "localforage": "^1.3.0",
     "lodash": "^4.13.1",
     "rimraf": "^2.4.4",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -29,6 +29,9 @@ var clearNamespaces = function(backendName, namespaces, done) {
  * Monkey-patch the secure clear method for testing because keytar doesn't
  * suport clearing the entire namespace automatically. Deletes all keys
  * that are used in the tests.
+ *
+ * @param {String}   namespace    namespace to clear
+ * @param {Function} done         callback
  */
 if (keytar) {
   backends.secure.clear = function(namespace, done) {


### PR DESCRIPTION
the behavior of `_.omit()` and `_.pick()` has changed, they no longer call the condition function. Need to use `_.omitBy()` and `_.pickBy()` methods instead for correct behavior.

https://lodash.com/docs/4.16.4#omitBy