### PR TITLE
fix: callback invoked twice on concurrent finds

### DIFF
--- a/lib/backends/secure-main.js
+++ b/lib/backends/secure-main.js
@@ -143,7 +143,8 @@ if (process && process.type === 'browser') {
       .then(function(credentials) {
         ipc.broadcast('storage-mixin:find:result', {
           namespace: meta.namespace,
-          credentials: credentials
+          credentials: credentials,
+          callId: meta.callId
         });
       })
       .catch(function(err) {


### PR DESCRIPTION
Ensure the listener of `storage-mixin:find:result` is invoked only once with the right result for each `storage-mixin:find` call. 

Changes:

- use a `callId` uuid on each `storage-mixin:find` call in order to filter results that are meant for other invocations.
- ensure each listener is called only once by removing it after the response has been received.